### PR TITLE
feat: devcontainerで環境構築できるようにする

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:24-bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+  git \
+  curl \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g \
+  @anthropic-ai/claude-code \
+  @openai/codex
+
+WORKDIR /workspace

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,13 @@
-FROM node:24-bookworm-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y \
   git \
   curl \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g \
-  @anthropic-ai/claude-code \
-  @openai/codex
+ENV NVM_DIR=/root/.nvm
+
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash \
+  && echo '. "$NVM_DIR/nvm.sh"' >> /root/.bashrc
 
 WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "offiter",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+  "forwardPorts": [3000],
+  "postCreateCommand": "npm install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-vscode.vscode-typescript-next"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "typescript.tsdk": "node_modules/typescript/lib"
+      }
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "workspaceFolder": "/workspace",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "forwardPorts": [3000],
-  "postCreateCommand": "npm install",
+  "postCreateCommand": ". $NVM_DIR/nvm.sh && nvm install && npm install -g @anthropic-ai/claude-code @openai/codex && npm install",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
## Summary

- `.devcontainer/Dockerfile` を追加 — NVMをインストールし、コンテナ起動時に `.nvmrc` からNodeバージョンを自動解決
- `.devcontainer/devcontainer.json` を追加 — ポート3000転送、VSCode拡張（ESLint/Prettier/TypeScript）設定
- `postCreateCommand` で `nvm install` → `@anthropic-ai/claude-code` / `@openai/codex` のグローバルインストール → `npm install` を実行

Closes #186

## Test plan

- [ ] devcontainerでコンテナを起動できる
- [ ] `claude` コマンドが実行できる
- [ ] `codex` コマンドが実行できる
- [ ] `npm run dev` が動作し、ポート3000でアクセスできる