### PR TITLE
fix: fix devcontainer startup flow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,20 @@
-FROM debian:bookworm-slim
+FROM ubuntu:24.04
 
-RUN apt-get update && apt-get install -y \
-  git \
-  curl \
-  && rm -rf /var/lib/apt/lists/*
-
+ENV HOME=/root
 ENV NVM_DIR=/root/.nvm
 
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash \
-  && echo '. "$NVM_DIR/nvm.sh"' >> /root/.bashrc
+# Use bash for the shell
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git curl ca-certificates
+
+# Create a script file sourced by both interactive and non-interactive bash shells
+ENV BASH_ENV "${HOME}/.bash_env"
+RUN touch "${BASH_ENV}"
+RUN echo '. "${BASH_ENV}"' >> ~/.bashrc
+
+# Download and install nvm
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | PROFILE="${BASH_ENV}" bash
 
 WORKDIR /workspace

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,19 +6,18 @@
   "workspaceFolder": "/workspace",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "forwardPorts": [3000],
-  "postCreateCommand": ". $NVM_DIR/nvm.sh && nvm install && npm install -g @anthropic-ai/claude-code @openai/codex && npm install",
+  "postCreateCommand": "bash -lc 'source \"$NVM_DIR/nvm.sh\" --no-use && nvm install && npm ci && nvm use && npm install -g @anthropic-ai/claude-code @openai/codex'",
   "customizations": {
     "vscode": {
-      "extensions": [
-        "dbaeumer.vscode-eslint",
-        "esbenp.prettier-vscode",
-        "ms-vscode.vscode-typescript-next"
-      ],
+      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "ms-vscode.vscode-typescript-next"],
       "settings": {
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "typescript.tsdk": "node_modules/typescript/lib"
+        "js/ts.tsdk.path": "node_modules/typescript/lib"
       }
     }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   }
 }


### PR DESCRIPTION
## Summary
- fix the devcontainer postCreate flow so nvm is sourced from bash without auto-using an uninstalled version
- switch the deprecated VS Code TypeScript SDK setting to js/ts.tsdk.path
- add the GitHub CLI devcontainer feature and commit the generated devcontainer lock file

## Testing
- bash -lc 'source "$NVM_DIR/nvm.sh" --no-use && nvm install && npm ci && nvm use && gh --version >/dev/null'